### PR TITLE
Add Resource model for custom permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The example includes a minimal content management system with an API for creatin
 
 ### Prisma Schema
 
-The `cms/prisma/schema.prisma` file defines database models for a basic CMS. It covers `User`, `Role`, `Permission`, `Post`, `Category` and `Media` similar to Strapi.
+The `cms/prisma/schema.prisma` file defines database models for a basic CMS. It covers `User`, `Role`, `Permission`, `Resource`, `Post`, `Category` and `Media` similar to Strapi.
 Run the following commands after installing dependencies to generate the Prisma client:
 
 ```bash

--- a/cms/prisma/schema.prisma
+++ b/cms/prisma/schema.prisma
@@ -30,9 +30,18 @@ model Role {
   permissions RolePermission[]
 }
 
+model Resource {
+  id          Int        @id @default(autoincrement())
+  name        String     @unique
+  description String?
+  permissions Permission[]
+}
+
 model Permission {
   id          Int              @id @default(autoincrement())
   action      String
+  resource    Resource   @relation(fields: [resourceId], references: [id])
+  resourceId  Int
   description String?
   roles       RolePermission[]
 }


### PR DESCRIPTION
## Summary
- expand Prisma schema to add a `Resource` model
- link `Permission` to `Resource`
- document the new table in the main README

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npx prisma format` *(fails: 403 Forbidden while downloading Prisma engines)*

------
https://chatgpt.com/codex/tasks/task_b_685448291714832484c9190e0325ad59