### PR TITLE
Add dynamic admin forms

### DIFF
--- a/cms/src/app/admin/content/[model]/Form.tsx
+++ b/cms/src/app/admin/content/[model]/Form.tsx
@@ -1,0 +1,134 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+'use client';
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+interface Field {
+  name: string;
+  type: string;
+  relationModel?: string;
+}
+
+interface Schema {
+  name: string;
+  fields: Field[];
+}
+
+export default function ModelForm({ model, id }: { model: string; id?: string }) {
+  const router = useRouter();
+  const [schema, setSchema] = useState<Schema | null>(null);
+  const [formData, setFormData] = useState<Record<string, any>>({});
+  const [relations, setRelations] = useState<Record<string, any[]>>({});
+
+  useEffect(() => {
+    fetch(`/api/models/${model}/schema`).then(res => res.json()).then(async (s) => {
+      setSchema(s);
+      for (const f of s.fields) {
+        if (f.relationModel) {
+          const res = await fetch(`/api/models/${f.relationModel}`);
+          const items = await res.json();
+          setRelations(r => ({ ...r, [f.name]: items }));
+        }
+      }
+    });
+    if (id) {
+      fetch(`/api/models/${model}/${id}`).then(res => res.json()).then(data => setFormData(data));
+    }
+  }, [model, id]);
+
+  function updateField(name: string, value: any) {
+    setFormData({ ...formData, [name]: value });
+  }
+
+  async function onSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    const res = await fetch(`/api/models/${model}${id ? '/' + id : ''}`, {
+      method: id ? 'PUT' : 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(formData),
+    });
+    if (res.ok) router.push(`/admin/content/${model}`);
+  }
+
+  if (!schema) return <p>Loading...</p>;
+
+  return (
+    <form onSubmit={onSubmit} className="flex flex-col space-y-4">
+      {schema.fields.map((field) => {
+        const value = formData[field.name] ?? '';
+        if (field.relationModel) {
+          const opts = relations[field.name] || [];
+          return (
+            <select
+              key={field.name}
+              value={value}
+              onChange={(e) => updateField(field.name, e.target.value)}
+              className="border p-2"
+            >
+              <option value="">Select {field.name}</option>
+              {opts.map((o) => (
+                <option key={o.id} value={o.id}>{o.id}</option>
+              ))}
+            </select>
+          );
+        }
+        switch (field.type) {
+          case 'Int':
+            return (
+              <input
+                key={field.name}
+                type="number"
+                className="border p-2"
+                value={value}
+                onChange={(e) => updateField(field.name, Number(e.target.value))}
+              />
+            );
+          case 'Boolean':
+            return (
+              <label key={field.name} className="flex items-center space-x-2">
+                <input
+                  type="checkbox"
+                  checked={Boolean(value)}
+                  onChange={(e) => updateField(field.name, e.target.checked)}
+                />
+                <span>{field.name}</span>
+              </label>
+            );
+          case 'DateTime':
+            return (
+              <input
+                key={field.name}
+                type="datetime-local"
+                className="border p-2"
+                value={value}
+                onChange={(e) => updateField(field.name, e.target.value)}
+              />
+            );
+          case 'Json':
+            return (
+              <textarea
+                key={field.name}
+                className="border p-2"
+                value={value}
+                onChange={(e) => updateField(field.name, e.target.value)}
+              />
+            );
+          default:
+            // treat as string
+            return (
+              <input
+                key={field.name}
+                type="text"
+                className="border p-2"
+                value={value}
+                onChange={(e) => updateField(field.name, e.target.value)}
+              />
+            );
+        }
+      })}
+      <button type="submit" className="p-2 bg-blue-500 text-white rounded">
+        {id ? 'Update' : 'Create'}
+      </button>
+    </form>
+  );
+}

--- a/cms/src/app/admin/content/[model]/[id]/edit/page.tsx
+++ b/cms/src/app/admin/content/[model]/[id]/edit/page.tsx
@@ -1,0 +1,15 @@
+"use client";
+import ModelForm from "../../Form";
+import { useParams } from 'next/navigation';
+
+export default function EditEntryPage() {
+  const params = useParams<{ model: string; id: string }>();
+  const model = Array.isArray(params.model) ? params.model[0] : params.model;
+  const id = Array.isArray(params.id) ? params.id[0] : params.id;
+  return (
+    <div>
+      <h1 className="text-xl font-bold mb-4">Edit {model}</h1>
+      <ModelForm model={model} id={id} />
+    </div>
+  );
+}

--- a/cms/src/app/admin/content/[model]/new/page.tsx
+++ b/cms/src/app/admin/content/[model]/new/page.tsx
@@ -1,0 +1,14 @@
+"use client";
+import ModelForm from '../Form';
+import { useParams } from 'next/navigation';
+
+export default function NewEntryPage() {
+  const params = useParams<{ model: string }>();
+  const model = Array.isArray(params.model) ? params.model[0] : params.model;
+  return (
+    <div>
+      <h1 className="text-xl font-bold mb-4">New {model}</h1>
+      <ModelForm model={model} />
+    </div>
+  );
+}

--- a/cms/src/app/admin/content/[model]/page.tsx
+++ b/cms/src/app/admin/content/[model]/page.tsx
@@ -1,0 +1,34 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+'use client';
+import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import LinkComp from 'next/link';
+
+export default function ModelListPage() {
+  const params = useParams<{ model: string }>();
+  const model = Array.isArray(params.model) ? params.model[0] : params.model;
+  const [items, setItems] = useState<any[]>([]);
+
+  useEffect(() => {
+    fetch(`/api/models/${model}`).then((res) => res.json()).then(setItems);
+  }, [model]);
+
+  return (
+    <div>
+      <h1 className="text-xl font-bold mb-4">{model} Entries</h1>
+      <LinkComp href={`/admin/content/${model}/new`} className="underline">
+        New {model}
+      </LinkComp>
+      <ul className="mt-4 space-y-2">
+        {items.map((item) => (
+          <li key={item.id} className="border p-2 rounded">
+            {JSON.stringify(item)}{' '}
+            <LinkComp href={`/admin/content/${model}/${item.id}/edit`} className="underline">
+              Edit
+            </LinkComp>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/cms/src/app/admin/layout.tsx
+++ b/cms/src/app/admin/layout.tsx
@@ -1,0 +1,3 @@
+export default function AdminLayout({ children }: { children: React.ReactNode }) {
+  return <div className="p-6">{children}</div>;
+}

--- a/cms/src/app/admin/page.tsx
+++ b/cms/src/app/admin/page.tsx
@@ -1,0 +1,3 @@
+export default function AdminHome() {
+  return <h1 className="text-xl font-bold">Admin</h1>;
+}

--- a/cms/src/app/api/models/[model]/[id]/route.ts
+++ b/cms/src/app/api/models/[model]/[id]/route.ts
@@ -1,0 +1,28 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { NextResponse, type NextRequest } from 'next/server';
+
+async function getPrisma() {
+  const { PrismaClient } = await import('@prisma/client');
+  return new PrismaClient();
+}
+
+function parseId(id: string) {
+  const n = Number(id);
+  return isNaN(n) ? id : n;
+}
+
+export async function GET(_req: NextRequest, context: unknown) {
+  const prisma = await getPrisma();
+  const params = (context as any).params as { model: string; id: string };
+  const item = await (prisma as any)[params.model].findUnique({ where: { id: parseId(params.id) } });
+  if (!item) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  return NextResponse.json(item);
+}
+
+export async function PUT(req: NextRequest, context: unknown) {
+  const prisma = await getPrisma();
+  const params = (context as any).params as { model: string; id: string };
+  const data = await req.json();
+  const item = await (prisma as any)[params.model].update({ where: { id: parseId(params.id) }, data });
+  return NextResponse.json(item);
+}

--- a/cms/src/app/api/models/[model]/route.ts
+++ b/cms/src/app/api/models/[model]/route.ts
@@ -1,0 +1,22 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { NextResponse, type NextRequest } from 'next/server';
+
+async function getPrisma() {
+  const { PrismaClient } = await import('@prisma/client');
+  return new PrismaClient();
+}
+
+export async function GET(_req: NextRequest, context: unknown) {
+  const prisma = await getPrisma();
+  const params = (context as any).params as { model: string };
+  const items = await (prisma as any)[params.model].findMany();
+  return NextResponse.json(items);
+}
+
+export async function POST(req: NextRequest, context: unknown) {
+  const prisma = await getPrisma();
+  const params = (context as any).params as { model: string };
+  const data = await req.json();
+  const item = await (prisma as any)[params.model].create({ data });
+  return NextResponse.json(item, { status: 201 });
+}

--- a/cms/src/app/api/models/[model]/schema/route.ts
+++ b/cms/src/app/api/models/[model]/schema/route.ts
@@ -1,0 +1,12 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { NextResponse, type NextRequest } from 'next/server';
+import { getModelSchema } from '@/lib/model-schema';
+
+export async function GET(_req: NextRequest, context: unknown) {
+  const params = (context as any).params as { model: string };
+  const schema = await getModelSchema(params.model);
+  if (!schema) {
+    return NextResponse.json({ error: 'Model not found' }, { status: 404 });
+  }
+  return NextResponse.json(schema);
+}

--- a/cms/src/lib/model-schema.ts
+++ b/cms/src/lib/model-schema.ts
@@ -1,0 +1,36 @@
+import { readFile } from 'fs/promises';
+import path from 'path';
+
+const SCHEMA_PATH = path.join(process.cwd(), 'prisma', 'schema.prisma');
+
+const SCALAR_TYPES = ['String', 'Int', 'Boolean', 'DateTime', 'Json'];
+
+export interface FieldMeta {
+  name: string;
+  type: string;
+  relationModel?: string;
+}
+
+export interface ModelMeta {
+  name: string;
+  fields: FieldMeta[];
+}
+
+export async function getModelSchema(model: string): Promise<ModelMeta | null> {
+  const schema = await readFile(SCHEMA_PATH, 'utf8');
+  const regex = new RegExp(`model\\s+${model}\\s+{([\\s\\S]*?)}`);
+  const match = schema.match(regex);
+  if (!match) return null;
+  const body = match[1];
+  const lines = body.split(/\n/).map(l => l.trim()).filter(l => l && !l.startsWith('@@'));
+  const fields: FieldMeta[] = [];
+  for (const line of lines) {
+    if (line.startsWith('//')) continue;
+    const [name, rawType] = line.split(/\s+/, 2);
+    if (!name || !rawType) continue;
+    const type = rawType.replace(/[?\[\]]/g, '');
+    const relation = !SCALAR_TYPES.includes(type) ? type : undefined;
+    fields.push({ name, type: type.replace(/\?.*/, ''), relationModel: relation });
+  }
+  return { name: model, fields };
+}


### PR DESCRIPTION
## Summary
- implement dynamic Prisma-based API routes
- add schema parser to read Prisma models
- add admin pages with generated forms for create/edit

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68579e5976408324ae95e165fbb6f999