### PR TITLE
Add ability to delete single types

### DIFF
--- a/cms/src/app/api/collections/[slug]/route.ts
+++ b/cms/src/app/api/collections/[slug]/route.ts
@@ -3,7 +3,7 @@ import { NextResponse, type NextRequest } from 'next/server';
 
 export async function GET(
   _req: NextRequest,
-  context: any
+  context: { params: { slug: string } }
 ) {
   const { params } = await context;
   const entries = await getEntries(params.slug);
@@ -12,7 +12,7 @@ export async function GET(
 
 export async function POST(
   request: NextRequest,
-  context: any
+  context: { params: { slug: string } }
 ) {
   const { params } = await context;
   const body = await request.json();

--- a/cms/src/app/api/singles/types/[slug]/route.ts
+++ b/cms/src/app/api/singles/types/[slug]/route.ts
@@ -1,0 +1,11 @@
+import { removeSingleType } from '@/lib/singles';
+import { NextResponse } from 'next/server';
+import type { NextRequest } from 'next/server';
+
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: { slug: string } }
+) {
+  await removeSingleType(params.slug);
+  return NextResponse.json({ ok: true });
+}

--- a/cms/src/app/dashboard/content-type-builder/single-types/page.tsx
+++ b/cms/src/app/dashboard/content-type-builder/single-types/page.tsx
@@ -43,13 +43,25 @@ export default function SingleTypesPage() {
     }
   }
 
+  async function deleteType(slugToDelete: string) {
+    await fetch(`/api/singles/types/${slugToDelete}`, { method: 'DELETE' });
+    setTypes((prev) => prev.filter((t) => t.slug !== slugToDelete));
+  }
+
   return (
     <div>
       <h1 className="text-xl font-bold mb-4">Single Types</h1>
       <ul className="space-y-2 mb-6">
         {types.map((t) => (
-          <li key={t.slug}>
-            <Link className="underline" href={`/dashboard/singles/${t.slug}`}>{t.name}</Link>
+          <li key={t.slug} className="flex items-center space-x-2">
+            <Link className="underline flex-1" href={`/dashboard/singles/${t.slug}`}>{t.name}</Link>
+            <button
+              type="button"
+              className="text-red-500"
+              onClick={() => deleteType(t.slug)}
+            >
+              Delete
+            </button>
           </li>
         ))}
       </ul>

--- a/cms/src/lib/singles.ts
+++ b/cms/src/lib/singles.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile, mkdir } from 'fs/promises';
+import { readFile, writeFile, mkdir, rm } from 'fs/promises';
 import path from 'path';
 
 export interface Field {
@@ -38,6 +38,14 @@ export async function addSingleType(type: SingleType) {
   await writeJSON(TYPE_PATH, types);
   await mkdir(path.join(DATA_DIR, type.slug), { recursive: true });
   await writeJSON(path.join(DATA_DIR, type.slug, 'entry.json'), {});
+}
+
+export async function removeSingleType(slug: string) {
+  const types = await getSingleTypes();
+  const filtered = types.filter((t) => t.slug !== slug);
+  if (filtered.length === types.length) return;
+  await writeJSON(TYPE_PATH, filtered);
+  await rm(path.join(DATA_DIR, slug), { recursive: true, force: true });
 }
 
 export async function getSingleEntry<T = unknown>(slug: string): Promise<T> {


### PR DESCRIPTION
## Summary
- add `removeSingleType` helper to remove single type folders and registry entries
- support DELETE /api/singles/types/[slug]
- allow deleting single types from UI

## Testing
- `npm run lint` *(fails: Unexpected any in another file)*

------
https://chatgpt.com/codex/tasks/task_b_685a2efc6ee88324ae03f917722963ed