### PR TITLE
Add env example and update setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,12 @@ NextCMS is a simple content management system (CMS) built with **Next.js** and *
    cd cms
    npm install
    ```
-2. Create a `.env` file in `cms` and specify the database connection:
+2. Copy the provided example env file and update it:
    ```bash
+   cp .env.example .env
    # Choose sqlite, mysql, or postgresql
-   DB_TYPE=sqlite
-   DATABASE_URL="file:./dev.db"
+   # DB_TYPE=sqlite
+   # DATABASE_URL="file:./dev.db"
    ```
 3. Generate the Prisma client and initialize the database:
    ```bash

--- a/cms/.env.example
+++ b/cms/.env.example
@@ -1,0 +1,4 @@
+# Example environment configuration for NextCMS
+# Choose sqlite, mysql, or postgresql
+DB_TYPE=sqlite
+DATABASE_URL="file:./dev.db"

--- a/cms/.gitignore
+++ b/cms/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/cms/README.md
+++ b/cms/README.md
@@ -1,36 +1,34 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# NextCMS App
 
-## Getting Started
+This directory contains the Next.js application for NextCMS.
 
-First, run the development server:
+## Setup
 
-```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
-```
+1. Install dependencies
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+   ```bash
+   npm install
+   ```
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+2. Copy `.env.example` to `.env` and adjust the values:
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+   ```bash
+   cp .env.example .env
+   # DB_TYPE=sqlite
+   # DATABASE_URL="file:./dev.db"
+   ```
 
-## Learn More
+3. Generate the Prisma client and set up the database:
 
-To learn more about Next.js, take a look at the following resources:
+   ```bash
+   npx prisma generate
+   npx prisma db push
+   ```
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+4. Start the development server:
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+   ```bash
+   npm run dev
+   ```
 
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+Visit <http://localhost:3000> to view the app.


### PR DESCRIPTION
## Summary
- add `.env.example` with DB env vars
- allow `.env.example` in gitignore
- update root README setup instructions
- replace cms README with step-by-step guide referencing env example

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_685a2efe85e88324bc57e741eaeab3f1