### PR TITLE
Add Playwright E2E testing setup

### DIFF
--- a/cms/e2e/admin.spec.ts
+++ b/cms/e2e/admin.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test';
+
+test('admin workflow', async ({ page }) => {
+  // Login
+  await page.goto('/dashboard/login');
+  await page.fill('input[type="text"]', 'admin');
+  await page.fill('input[type="password"]', 'password');
+  await page.getByRole('button', { name: 'Login' }).click();
+  await expect(page).toHaveURL(/\/dashboard$/);
+  await expect(page.getByText('Dashboard Home')).toBeVisible();
+
+  // Create collection type
+  await page.goto('/dashboard/collections');
+  await page.fill('input[placeholder="Name"]', 'Books');
+  await page.fill('input[placeholder="Slug"]', 'books');
+  await page.fill('input[placeholder="Field name"]', 'title');
+  await page.getByRole('button', { name: 'Add Field' }).click();
+  const fields = page.locator('input[placeholder="Field name"]');
+  await fields.nth(1).fill('author');
+  await page.getByRole('button', { name: 'Add Collection' }).click();
+  await expect(page.locator('a', { hasText: 'Books' })).toBeVisible();
+
+  // Create content entry
+  await page.click('a[href="/dashboard/collections/books"]');
+  await page.fill('input[placeholder="title"]', 'My Book');
+  await page.fill('input[placeholder="author"]', 'Alice');
+  await page.getByRole('button', { name: 'Add Entry' }).click();
+  await expect(page.locator('li').filter({ hasText: 'My Book' })).toBeVisible();
+
+  // Logout by clearing storage
+  await page.evaluate(() => localStorage.removeItem('isLoggedIn'));
+  await page.goto('/dashboard/login');
+  await expect(page).toHaveURL('/dashboard/login');
+});

--- a/cms/package-lock.json
+++ b/cms/package-lock.json
@@ -19,6 +19,7 @@
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
+        "@playwright/test": "^1.42.1",
         "@tailwindcss/postcss": "^4",
         "@types/jest": "^29.5.11",
         "@types/node": "^20",
@@ -27,6 +28,7 @@
         "eslint": "^9",
         "eslint-config-next": "15.3.4",
         "jest": "^29.7.0",
+        "playwright": "^1.42.1",
         "prisma": "^5.15.0",
         "tailwindcss": "^4",
         "ts-jest": "^29.1.1",
@@ -2032,6 +2034,23 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.42.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.42.1.tgz",
+      "integrity": "sha512-Gq9rmS54mjBL/7/MvBaNOBwbfnh7beHvS6oS4srqXFcQHpQCV1+c8JXWE8VLPyRDhgS3H8x8A7hztqI9VnwrAQ==",
+      "deprecated": "Please update to the latest version of Playwright to test up-to-date browsers.",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.42.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@prisma/client": {
@@ -9233,6 +9252,53 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.42.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.42.1.tgz",
+      "integrity": "sha512-PgwB03s2DZBcNRoW+1w9E+VkLBxweib6KTXM0M3tkiT4jVxKSi6PmVJ591J+0u10LUrgxB7dLRbiJqO5s2QPMg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.42.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.42.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.42.1.tgz",
+      "integrity": "sha512-mxz6zclokgrke9p1vtdy/COWBH+eOZgYUVVU34C73M+4j4HLlQJHtfcqiqqxpP0o8HhMkflvfbquLX5dg6wlfA==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/cms/package.json
+++ b/cms/package.json
@@ -7,31 +7,34 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "test": "jest"
+    "test": "jest",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
+    "@prisma/client": "^5.15.0",
+    "mysql2": "^3",
+    "next": "15.3.4",
+    "pg": "^8",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "next": "15.3.4",
-    "@prisma/client": "^5.15.0",
-    "sqlite3": "^5",
     "sqlite": "^5",
-    "mysql2": "^3",
-    "pg": "^8"
+    "sqlite3": "^5"
   },
   "devDependencies": {
-    "typescript": "^5",
+    "@eslint/eslintrc": "^3",
+    "@playwright/test": "^1.42.1",
+    "@tailwindcss/postcss": "^4",
+    "@types/jest": "^29.5.11",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@tailwindcss/postcss": "^4",
-    "tailwindcss": "^4",
     "eslint": "^9",
     "eslint-config-next": "15.3.4",
-    "@eslint/eslintrc": "^3",
-    "prisma": "^5.15.0",
     "jest": "^29.7.0",
+    "playwright": "^1.42.1",
+    "prisma": "^5.15.0",
+    "tailwindcss": "^4",
     "ts-jest": "^29.1.1",
-    "@types/jest": "^29.5.11"
+    "typescript": "^5"
   }
 }

--- a/cms/playwright.config.ts
+++ b/cms/playwright.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  webServer: {
+    command: 'npm run dev',
+    port: 3000,
+    timeout: 120 * 1000,
+    reuseExistingServer: true,
+  },
+});

--- a/cms/yarn.lock
+++ b/cms/yarn.lock
@@ -879,6 +879,13 @@
     mkdirp "^1.0.4"
     rimraf "^3.0.2"
 
+"@playwright/test@^1.41.2", "@playwright/test@^1.42.1":
+  version "1.42.1"
+  resolved "https://registry.npmjs.org/@playwright/test/-/test-1.42.1.tgz"
+  integrity sha512-Gq9rmS54mjBL/7/MvBaNOBwbfnh7beHvS6oS4srqXFcQHpQCV1+c8JXWE8VLPyRDhgS3H8x8A7hztqI9VnwrAQ==
+  dependencies:
+    playwright "1.42.1"
+
 "@prisma/client@^5.15.0":
   version "5.22.0"
   resolved "https://registry.npmjs.org/@prisma/client/-/client-5.22.0.tgz"
@@ -2739,6 +2746,11 @@ fsevents@^2.3.2, fsevents@2.3.3:
   version "2.3.3"
   resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
+
+fsevents@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
 function-bind@^1.1.2:
   version "1.1.2"
@@ -4611,6 +4623,20 @@ pkg-dir@^4.2.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
+
+playwright-core@1.42.1:
+  version "1.42.1"
+  resolved "https://registry.npmjs.org/playwright-core/-/playwright-core-1.42.1.tgz"
+  integrity sha512-mxz6zclokgrke9p1vtdy/COWBH+eOZgYUVVU34C73M+4j4HLlQJHtfcqiqqxpP0o8HhMkflvfbquLX5dg6wlfA==
+
+playwright@^1.42.1, playwright@1.42.1:
+  version "1.42.1"
+  resolved "https://registry.npmjs.org/playwright/-/playwright-1.42.1.tgz"
+  integrity sha512-PgwB03s2DZBcNRoW+1w9E+VkLBxweib6KTXM0M3tkiT4jVxKSi6PmVJ591J+0u10LUrgxB7dLRbiJqO5s2QPMg==
+  dependencies:
+    playwright-core "1.42.1"
+  optionalDependencies:
+    fsevents "2.3.2"
 
 possible-typed-array-names@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
## Summary
- install Playwright and @playwright/test
- add basic Playwright configuration
- create an admin workflow test covering login, schema creation and content entry
- expose `test:e2e` script

## Testing
- `npm run test:e2e` *(fails: browser executable not found)*

------
https://chatgpt.com/codex/tasks/task_b_685d0f72638c832491e17f190d2db4d9