### PR TITLE
Filter CMS models

### DIFF
--- a/cms/src/lib/model-schema.ts
+++ b/cms/src/lib/model-schema.ts
@@ -5,6 +5,25 @@ const SCHEMA_PATH = path.join(process.cwd(), 'prisma', 'schema.prisma');
 
 const SCALAR_TYPES = ['String', 'Int', 'Boolean', 'DateTime', 'Json'];
 
+export const CMS_MODELS = [
+  'User',
+  'Role',
+  'Resource',
+  'Permission',
+  'RolePermission',
+  'Post',
+  'Category',
+  'PostCategory',
+  'Media',
+  'CollectionType',
+  'CollectionEntry',
+  'SingleType',
+  'SingleEntry',
+  'Component',
+  'ContentType',
+  'ContentItem',
+];
+
 export interface FieldMeta {
   name: string;
   type: string;
@@ -19,7 +38,9 @@ export interface ModelMeta {
 export async function getModelNames(): Promise<string[]> {
   const schema = await readFile(SCHEMA_PATH, 'utf8');
   const matches = [...schema.matchAll(/model\s+(\w+)\s+\{/g)];
-  return matches.map((m: RegExpMatchArray) => m[1]);
+  return matches
+    .map((m: RegExpMatchArray) => m[1])
+    .filter((name) => CMS_MODELS.includes(name));
 }
 
 export async function getModelSchema(model: string): Promise<ModelMeta | null> {

--- a/cms/tests/model-schema.test.ts
+++ b/cms/tests/model-schema.test.ts
@@ -1,0 +1,27 @@
+import { jest } from '@jest/globals';
+
+jest.mock('fs/promises', () => ({
+  readFile: jest.fn(),
+}));
+
+import { readFile } from 'fs/promises';
+import { getModelNames } from '@/lib/model-schema';
+
+const mockReadFile = readFile as jest.Mock;
+
+const sampleSchema = `
+model User { id Int @id }
+model Account { id Int @id }
+model Post { id Int @id }
+`;
+
+describe('getModelNames', () => {
+  beforeEach(() => {
+    mockReadFile.mockResolvedValue(sampleSchema);
+  });
+
+  test('filters to CMS models', async () => {
+    const names = await getModelNames();
+    expect(names).toEqual(['User', 'Post']);
+  });
+});


### PR DESCRIPTION
## Summary
- limit model list to CMS models via new `CMS_MODELS` array
- filter models directly in `getModelNames`
- provide Jest test coverage
- simplify `/api/models` route

## Testing
- `npx --yes jest -c cms/jest.config.js`

------
https://chatgpt.com/codex/tasks/task_b_68677c84b6748324a6c13e59880cded5